### PR TITLE
Add capability to generate secret values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.1 (UNRELEASED)
 
 * Add masking support [#1](https://github.com/fpco/amber/issues/1)
+* Add subcommand `generate` [#7](https://github.com/fpco/amber/pull/7)
 
 ## 0.1.0 (2021-08)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,11 @@ pub enum SubCommand {
         /// Value
         value: String,
     },
+    /// Generate a new strong secret value, and add it to the repository
+    Generate {
+        /// Key, must be all capital ASCII characters, digits, and underscores
+        key: String,
+    },
     /// Remove a secret
     Remove {
         /// Key, must be all capital ASCII characters, digits, and underscores

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
     match cmd.sub {
         cli::SubCommand::Init => init(cmd.opt),
         cli::SubCommand::Encrypt { key, value } => encrypt(cmd.opt, key, value),
+        cli::SubCommand::Generate { key } => generate(cmd.opt, key),
         cli::SubCommand::Remove { key } => remove(cmd.opt, key),
         cli::SubCommand::Print => print(cmd.opt),
         cli::SubCommand::Exec { cmd: cmd_, args } => exec(cmd.opt, cmd_, args),
@@ -54,6 +55,15 @@ fn encrypt(opt: cli::Opt, key: String, value: String) -> Result<()> {
     let mut config = config::Config::load(&opt.amber_yaml)?;
     config.encrypt(key, &value);
     config.save(&opt.amber_yaml)
+}
+
+fn generate(opt: cli::Opt, key: String) -> Result<()> {
+    let value = sodiumoxide::randombytes::randombytes(16);
+    let value = sodiumoxide::base64::encode(value, sodiumoxide::base64::Variant::UrlSafe);
+    let msg = format!("Your new secret value is {}: {}", key, value);
+    let res = encrypt(opt, key, value)?;
+    println!("{}", &msg);
+    Ok(res)
 }
 
 fn remove(opt: cli::Opt, key: String) -> Result<()> {


### PR DESCRIPTION
I added a quick feature to automatically generate new secret values and add them to the config. Is this something you'd find useful?

```
> amber generate KEY1
Your new secret value is KEY1: awUHt_Z9UKmYzDp2HKPz8A==

❯ cat amber.yaml
---
file_format_version: 1
public_key: <redacted>
secrets:
  - name: KEY1
    sha256: dba4b63c27dc8827b465594894f6e5c6901a75799ca7b5c00c1b7740128237a8
    cipher: <redacted>
```