### PR TITLE
Turned on a few release options to minimize the size of the Linux binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,9 @@ jobs:
     - name: Install musl tools
       run: sudo apt-get install -y musl-tools
     - name: Build
-      run: cargo build --release --target x86_64-unknown-linux-musl
+      run: |
+        cargo build --release --target x86_64-unknown-linux-musl
+        strip target/x86_64-unknown-linux-musl/release/amber
     - name: Rename
       run: |
         mkdir artifacts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ sodiumoxide = "0.2.7"
 [build-dependencies]
 anyhow = "1"
 vergen = { version = "5.1.1", default-features = false, features = ["git"] }
+
+[profile.release]
+panic = "abort"
+opt-level = "z"
+lto = true


### PR DESCRIPTION
No reason. Just that it can be done.

There are a few features in nightly, that may reduce another < 1 MiB.

I want to confirm this by running the action in my repo, but Github just could not detect the workflow.