### PR TITLE
Do vergen initialization only when .git directory is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Add masking support [#1](https://github.com/fpco/amber/issues/1)
 * Add subcommand `generate` [#7](https://github.com/fpco/amber/pull/7)
+* Do `vergen` initialization only when `.git` directory is
+  present. This makes amber easy to package for distributions like
+  NixOS.
 
 ## 0.1.0 (2021-08)
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,11 @@
 use anyhow::*;
+use std::path::Path;
 use vergen::{vergen, Config};
 
 fn main() -> Result<()> {
-    vergen(Config::default())
+    if Path::new(".git").exists() {
+        vergen(Config::default())
+    } else {
+        Ok(())
+    }
 }


### PR DESCRIPTION
This makes it easy to package for a distribution like NixOS or for a system where tarballs are downloaded and they try to build the `amber` executable on it.