### PR TITLE
Search amber.yaml in parent directory in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 0.1.2 (UNRELEASED)
 
 * Allow `encrypt` subcommand to take secret value from `stdin` [#15](https://github.com/fpco/amber/issues/15)
+* Amber searches the parent directory for the amber.yaml file if
+  amber.yaml isn't present in the current working directory. This
+  check is only done when no explicit amber-yaml is specificed (unless
+  the specified amber yaml itself is amber.yaml which is the default
+  value)
 
 ## 0.1.1 (2021-08-31)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use anyhow::*;
 use clap::Clap;
 use once_cell::sync::Lazy;
 
@@ -88,7 +89,7 @@ static VERSION_SHA: Lazy<String> = Lazy::new(|| {
     }
 });
 
-pub(crate) const DEFAULT_AMBER_YAML: &str = "amber.yaml";
+const DEFAULT_AMBER_YAML: &str = "amber.yaml";
 
 /// Utility to store encrypted secrets in version trackable plain text files.
 #[derive(Clap, Debug)]
@@ -97,8 +98,8 @@ pub struct Opt {
     #[clap(short, long, global = true)]
     pub verbose: bool,
     /// amber.yaml file location
-    #[clap(long, default_value = DEFAULT_AMBER_YAML, global = true, env = "AMBER_YAML")]
-    pub amber_yaml: PathBuf,
+    #[clap(long, global = true, env = "AMBER_YAML")]
+    pub amber_yaml: Option<PathBuf>,
     /// Disable masking of secret values during exec
     #[clap(long, global = true)]
     pub unmasked: bool,
@@ -113,5 +114,29 @@ impl Opt {
         let level = if self.verbose { Debug } else { Info };
         builder.filter_module(env!("CARGO_CRATE_NAME"), level);
         builder.target(Target::Stderr).init();
+    }
+
+    pub fn find_amber_yaml(&mut self) -> Result<&Path> {
+        if self.amber_yaml.is_none() {
+            for dir in std::env::current_dir()?.ancestors() {
+                let amber_yaml: PathBuf = dir.join(DEFAULT_AMBER_YAML);
+                log::debug!("Checking if file {:?} exists", &amber_yaml);
+                if amber_yaml.exists() {
+                    self.amber_yaml = Some(amber_yaml);
+                    break;
+                }
+            }
+        }
+        self.amber_yaml
+            .as_deref()
+            .with_context(|| format!("No file named {} found", DEFAULT_AMBER_YAML))
+    }
+
+    pub fn find_amber_yaml_or_default(&mut self) -> &Path {
+        if self.amber_yaml.is_none() {
+            self.amber_yaml = Some(Path::new(DEFAULT_AMBER_YAML).to_owned());
+        }
+
+        self.amber_yaml.as_deref().unwrap()
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,8 @@ static VERSION_SHA: Lazy<String> = Lazy::new(|| {
     }
 });
 
+pub(crate) const DEFAULT_AMBER_YAML: &str = "amber.yaml";
+
 /// Utility to store encrypted secrets in version trackable plain text files.
 #[derive(Clap, Debug)]
 pub struct Opt {
@@ -95,7 +97,7 @@ pub struct Opt {
     #[clap(short, long, global = true)]
     pub verbose: bool,
     /// amber.yaml file location
-    #[clap(long, default_value = "amber.yaml", global = true, env = "AMBER_YAML")]
+    #[clap(long, default_value = DEFAULT_AMBER_YAML, global = true, env = "AMBER_YAML")]
     pub amber_yaml: PathBuf,
     /// Disable masking of secret values during exec
     #[clap(long, global = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,10 +133,7 @@ impl Opt {
     }
 
     pub fn find_amber_yaml_or_default(&mut self) -> &Path {
-        if self.amber_yaml.is_none() {
-            self.amber_yaml = Some(Path::new(DEFAULT_AMBER_YAML).to_owned());
-        }
-
-        self.amber_yaml.as_deref().unwrap()
+        self.amber_yaml
+            .get_or_insert_with(|| Path::new(DEFAULT_AMBER_YAML).to_owned())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,7 +124,9 @@ impl Config {
         let path: PathBuf = path.as_ref().into();
         let new_path = if path == PathBuf::from(crate::cli::DEFAULT_AMBER_YAML) {
             find_amber_yaml(&path)
-        } else { Ok(path) };
+        } else {
+            Ok(path)
+        };
         let load_path = new_path?;
         let res: Result<Self> = (|| {
             let mut file = fs_err::File::open(&load_path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path, path::PathBuf};
+use std::{collections::HashMap, path::Path};
 
 use anyhow::*;
 use serde::{Deserialize, Serialize};
@@ -121,19 +121,13 @@ impl Config {
     }
 
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let path: PathBuf = path.as_ref().into();
-        let new_path = if path == PathBuf::from(crate::cli::DEFAULT_AMBER_YAML) {
-            find_amber_yaml(&path)
-        } else {
-            Ok(path)
-        };
-        let load_path = new_path?;
+        let path = path.as_ref();
         let res: Result<Self> = (|| {
-            let mut file = fs_err::File::open(&load_path)?;
+            let mut file = fs_err::File::open(path)?;
             let config = serde_yaml::from_reader(&mut file)?;
             Config::from_raw(config)
         })();
-        res.with_context(|| format!("Unable to read file {}", load_path.display()))
+        res.with_context(|| format!("Unable to read file {}", path.display()))
     }
 
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
@@ -244,19 +238,4 @@ impl Secret {
         })()
         .with_context(|| format!("Error while decrypting secret named {}", key))
     }
-}
-
-fn find_amber_yaml<P: AsRef<Path>>(name: P) -> Result<PathBuf> {
-    if name.as_ref().is_file() {
-        return Ok(name.as_ref().to_path_buf());
-    }
-    let path = std::env::current_dir()?;
-    for file in path.ancestors() {
-        let amber_yaml: PathBuf = file.join(&name);
-        log::debug!("Checking if file {:?} exists", &amber_yaml);
-        if amber_yaml.exists() {
-            return Ok(amber_yaml);
-        }
-    }
-    bail!("No file named {} found", &name.as_ref().display())
 }


### PR DESCRIPTION
This PR makes amber searches the parent directory for the amber.yaml
file if amber.yaml isn't present in the current working
directory.

This check is only done when no explicit amber-yaml is specificed via
--amber-yaml option or via the environment variable (unless the
specified value matches the default amber.yaml value)

Fixes #21