### PR TITLE
Update clap and other dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ version = "0.1.2"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "assert_cmd",
  "clap",
  "env_logger",
  "fs-err",
@@ -32,9 +33,23 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e996dc7940838b7ef1096b882e29ec30a3149a3a443cdc8dba19ed382eca1fe2"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "atty"
@@ -58,6 +73,17 @@ name = "bitflags"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
 
 [[package]]
 name = "cc"
@@ -89,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
 dependencies = [
  "atty",
  "bitflags",
@@ -102,15 +128,13 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -120,10 +144,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "ed25519"
@@ -133,6 +163,12 @@ checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "signature",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enum-iterator"
@@ -271,10 +307,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.7"
+name = "itertools"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -381,15 +426,18 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -408,6 +456,33 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
+dependencies = [
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -512,6 +587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,18 +630,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -569,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
  "itoa",
  "ryu",
@@ -580,12 +661,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
- "linked-hash-map",
+ "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]
@@ -649,13 +730,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.12.1"
+name = "termtree"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-dependencies = [
- "unicode-width",
-]
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -725,12 +809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,16 +833,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "vergen"
-version = "5.1.15"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265455aab08c55a1ab13f07c8d5e25c7d46900f4484dd7cbd682e77171f93f3c"
+checksum = "fd0c9f8387e118573859ae0e6c6fbdfa41bd1f4fbea451b0b8c5a81a3b8bc9e0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -781,6 +853,15 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,24 +12,25 @@ keywords = ["continuous-integration", "secrets", "encryption"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-aho-corasick = "0.7"
-anyhow = "1"
-clap = "~3.0.0-beta.2"
-env_logger = "0.9"
-fs-err = "2.6"
-log = "0.4"
-once_cell = "1.8"
-serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.8.17"
-serde_json = "1.0.66"
+aho-corasick = "0.7.18"
+anyhow = "1.0.52"
+clap = { version = "3.0.0", features = ["derive", "env"]}
+env_logger = "0.9.0"
+fs-err = "2.6.0"
+log = "0.4.14"
+once_cell = "1.9.0"
+serde = { version = "1.0.132", features = ["derive"] }
+serde_yaml = "0.8.23"
+serde_json = "1.0.73"
 sodiumoxide = "0.2.7"
 
 [build-dependencies]
-anyhow = "1"
-vergen = { version = "5.1.1", default-features = false, features = ["git"] }
+anyhow = "1.0.52"
+vergen = { version = "6.0.0", default-features = false, features = ["git"] }
 
 [dev-dependencies]
-tempfile = "3"
+assert_cmd = "2.0.2"
+tempfile = "3.2.0"
 
 [profile.release]
 panic = "abort"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::*;
-use clap::Clap;
+use clap::{Parser, Subcommand};
 use once_cell::sync::Lazy;
 
 pub fn init() -> Cmd {
@@ -10,7 +10,7 @@ pub fn init() -> Cmd {
     cmd
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(version = VERSION_SHA.as_str())]
 pub struct Cmd {
     #[clap(flatten)]
@@ -19,7 +19,7 @@ pub struct Cmd {
     pub sub: SubCommand,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum SubCommand {
     /// Initialize a new directory
     Init,
@@ -55,7 +55,7 @@ pub enum SubCommand {
     },
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 pub enum PrintStyle {
     /// Output with `export` prefix, can be evaled in shell.
     SetEnv,
@@ -66,17 +66,14 @@ pub enum PrintStyle {
 }
 
 impl core::str::FromStr for PrintStyle {
-    type Err = clap::Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "setenv" => Ok(PrintStyle::SetEnv),
             "json" => Ok(PrintStyle::Json),
             "yaml" => Ok(PrintStyle::Yaml),
-            _ => Err(clap::Error::with_description(
-                String::from("Invalid option for Print command"),
-                clap::ErrorKind::InvalidValue,
-            )),
+            _ => Err(anyhow!("Invalid option for Print command")),
         }
     }
 }
@@ -92,7 +89,7 @@ static VERSION_SHA: Lazy<String> = Lazy::new(|| {
 const DEFAULT_AMBER_YAML: &str = "amber.yaml";
 
 /// Utility to store encrypted secrets in version trackable plain text files.
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 pub struct Opt {
     /// Turn on verbose output
     #[clap(short, long, global = true)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,10 @@ fn encrypt(mut opt: cli::Opt, key: String, value: Option<String>) -> Result<()> 
             let stdin = std::io::stdin();
             let mut stdin = stdin.lock();
             let mut buffer = String::new();
-            stdin.read_to_string(&mut buffer).map(|_size| buffer)
+            stdin
+                .read_to_string(&mut buffer)
+                .map(|_size| buffer)
+                .map_err(anyhow::Error::new)
         },
         Ok,
     )?;

--- a/tests/encrypt.rs
+++ b/tests/encrypt.rs
@@ -1,4 +1,6 @@
+use assert_cmd::prelude::*;
 use std::io::Write;
+use std::process::Command;
 use std::{path::Path, process::Stdio};
 
 const AMBER_YAML: &str = "assets/amber-encrypt.yaml";
@@ -17,9 +19,8 @@ struct Pair {
 }
 
 fn get_vars(path: impl AsRef<Path>) -> Vec<Pair> {
-    let output = std::process::Command::new("cargo")
-        .arg("run")
-        .arg("--")
+    let output = Command::cargo_bin("amber")
+        .unwrap()
         .arg("print")
         .arg("--style")
         .arg("json")
@@ -43,9 +44,8 @@ fn empty_file() {
 #[test]
 fn encrypt_cli() {
     let temp = temp_amber_yaml();
-    let status = std::process::Command::new("cargo")
-        .arg("run")
-        .arg("--")
+    let status = Command::cargo_bin("amber")
+        .unwrap()
         .arg("encrypt")
         .arg("FOO")
         .arg("foovalue")
@@ -65,9 +65,8 @@ fn encrypt_cli() {
 #[test]
 fn encrypt_stdin() {
     let temp = temp_amber_yaml();
-    let mut child = std::process::Command::new("cargo")
-        .arg("run")
-        .arg("--")
+    let mut child = Command::cargo_bin("amber")
+        .unwrap()
         .arg("encrypt")
         .arg("FOO")
         .env("AMBER_YAML", temp.as_os_str())

--- a/tests/masking.rs
+++ b/tests/masking.rs
@@ -1,3 +1,6 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
 const AMBER_YAML: &str = "assets/amber-masking.yaml";
 const SECRET_KEY: &str = "ac2af4852f3de2dc6feb19b718d1cbf6c64c1ef618dafaf2b0a89cadcde240ac";
 const TO_MASK: &str = include_str!("../assets/tomask.txt");
@@ -5,9 +8,8 @@ const MASKED: &str = include_str!("../assets/masked.txt");
 
 #[test]
 fn masking() {
-    let output = std::process::Command::new("cargo")
-        .arg("run")
-        .arg("--")
+    let output = Command::cargo_bin("amber")
+        .unwrap()
         .arg("exec")
         .arg("cat")
         .arg("assets/tomask.txt")
@@ -24,9 +26,8 @@ fn masking() {
 
 #[test]
 fn disable_masking() {
-    let output = std::process::Command::new("cargo")
-        .arg("run")
-        .arg("--")
+    let output = Command::cargo_bin("amber")
+        .unwrap()
         .arg("exec")
         .arg("--unmasked")
         .arg("cat")


### PR DESCRIPTION
Summary of the updates:
- Clap v3 has been released and this PR updates to use it. I did a
`cargo upgrade` to update all the other dependencies, but if you
prefer me just updraing clap, I can go ahead and do that.
- Use assert_cmd for testing cli. This gives a cargo_bin method which
is more convenient for integration tests rather than doing cargo run.