### PR TITLE
Add option to display only secret key when exec amber init

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,9 @@ pub struct Opt {
     /// Disable masking of secret values during exec
     #[clap(long, global = true)]
     pub unmasked: bool,
+    /// Display only secret key when exec amber init
+    #[clap(long, global = true)]
+    pub only_secret_key: bool,
 }
 
 impl Opt {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,14 +48,17 @@ fn init(mut opt: cli::Opt) -> Result<()> {
 
     config.save(opt.find_amber_yaml_or_default())?;
 
-    eprintln!("Your secret key is: {}", secret_key);
-    eprintln!(
-        "Please save this key immediately! If you lose it, you will lose access to your secrets."
-    );
-    eprintln!("Recommendation: keep it in a password manager");
-    eprintln!("If you're using this for CI, please update your CI configuration with a secret environment variable");
-    println!("export {}={}", config::SECRET_KEY_ENV, secret_key);
-
+    if opt.only_secret_key {
+        println!("{}", secret_key);
+    } else {
+        eprintln!("Your secret key is: {}", secret_key);
+        eprintln!(
+            "Please save this key immediately! If you lose it, you will lose access to your secrets."
+        );
+        eprintln!("Recommendation: keep it in a password manager");
+        eprintln!("If you're using this for CI, please update your CI configuration with a secret environment variable");
+        println!("export {}={}", config::SECRET_KEY_ENV, secret_key);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
amber is display secret key to console when execute `amber init`.
But, I think there are times when want not to display secret to console.

So, add `--only-secret-key` option and use the following:

```
amber init --only-secret-key | pbcopy
```
