### PR TITLE
Migrate from sodiumoxide to crypto_box

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,18 +28,18 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "assert_cmd",
+ "base64",
  "clap",
- "crypto_box 0.8.1 (git+https://github.com/RustCrypto/nacl-compat.git?rev=0a0c83f99f37340aeab1a3ce083e9e22080cf6ff)",
+ "crypto_box",
  "env_logger",
  "fs-err",
  "hex",
  "log",
  "once_cell",
- "sealed-box",
  "serde",
  "serde_json",
  "serde_yaml",
- "sodiumoxide",
+ "sha2",
  "tempfile",
  "vergen",
 ]
@@ -80,6 +80,12 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -232,21 +238,6 @@ dependencies = [
 [[package]]
 name = "crypto_box"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbf5d97a01c39dad83e20de5398748bbbb0ffd307b9612cf0db74ab3c88d551"
-dependencies = [
- "aead",
- "chacha20",
- "chacha20poly1305",
- "salsa20",
- "x25519-dalek",
- "xsalsa20poly1305",
- "zeroize",
-]
-
-[[package]]
-name = "crypto_box"
-version = "0.8.1"
 source = "git+https://github.com/RustCrypto/nacl-compat.git?rev=0a0c83f99f37340aeab1a3ce083e9e22080cf6ff#0a0c83f99f37340aeab1a3ce083e9e22080cf6ff"
 dependencies = [
  "aead",
@@ -303,15 +294,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "ed25519"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
-dependencies = [
- "signature",
-]
 
 [[package]]
 name = "either"
@@ -544,18 +526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsodium-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "walkdir",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,12 +609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
 name = "predicates"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,27 +675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -812,24 +755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "sealed-box"
-version = "0.2.0"
-dependencies = [
- "blake2",
- "crypto_box 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,21 +799,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "1.3.1"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
-
-[[package]]
-name = "sodiumoxide"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "ed25519",
- "libc",
- "libsodium-sys",
- "serde",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -1097,17 +1015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,10 +29,13 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "crypto_box 0.8.1 (git+https://github.com/RustCrypto/nacl-compat.git?rev=0a0c83f99f37340aeab1a3ce083e9e22080cf6ff)",
  "env_logger",
  "fs-err",
+ "hex",
  "log",
  "once_cell",
+ "sealed-box",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -75,6 +88,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
+name = "blake2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+dependencies = [
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +115,12 @@ dependencies = [
  "memchr",
  "regex-automata",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -99,6 +136,41 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
 
 [[package]]
 name = "clap"
@@ -138,10 +210,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbf5d97a01c39dad83e20de5398748bbbb0ffd307b9612cf0db74ab3c88d551"
+dependencies = [
+ "aead",
+ "chacha20",
+ "chacha20poly1305",
+ "salsa20",
+ "x25519-dalek",
+ "xsalsa20poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.8.1"
+source = "git+https://github.com/RustCrypto/nacl-compat.git?rev=0a0c83f99f37340aeab1a3ce083e9e22080cf6ff#0a0c83f99f37340aeab1a3ce083e9e22080cf6ff"
+dependencies = [
+ "aead",
+ "blake2",
+ "chacha20",
+ "chacha20poly1305",
+ "salsa20",
+ "x25519-dalek",
+ "xsalsa20poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "doc-comment"
@@ -223,6 +378,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64db3e262960f0662f43a6366788d5f10f7f244b8f7d7d987f560baf5ded5c50"
 
 [[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getset"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +475,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -413,6 +604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +626,23 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
@@ -500,6 +714,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,12 +803,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sealed-box"
+version = "0.2.0"
+dependencies = [
+ "blake2",
+ "crypto_box 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand",
 ]
 
 [[package]]
@@ -630,6 +898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +912,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -716,6 +1002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +1026,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -803,6 +1111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,3 +1146,48 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "x25519-dalek"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "xsalsa20poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472c385ee974833d7e59979eeb74175d56774be3768b5bcc581337e21396bda3"
+dependencies = [
+ "aead",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,8 +237,9 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.8.1"
-source = "git+https://github.com/RustCrypto/nacl-compat.git?rev=0a0c83f99f37340aeab1a3ce083e9e22080cf6ff#0a0c83f99f37340aeab1a3ce083e9e22080cf6ff"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd26c32de5307fd08aac445a75c43472b14559d5dccdfba8022dbcd075838ebc"
 dependencies = [
  "aead",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_yaml = "0.9.13"
 serde_json = "1.0.85"
 sodiumoxide = "0.2.7"
+sealed-box = { path = "../sealed_box/" }
+crypto_box = { git = "https://github.com/RustCrypto/nacl-compat.git", rev = "0a0c83f99f37340aeab1a3ce083e9e22080cf6ff", features = ["seal"]}
+hex = "0.4.3"
 
 [build-dependencies]
 anyhow = "1.0.65"
@@ -32,12 +35,12 @@ vergen = { version = "7.4.2", default-features = false, features = ["git"] }
 assert_cmd = "2.0.4"
 tempfile = "3.3.0"
 
-[profile.dev]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much.
-debug = 0
+# [profile.dev]
+# # Disabling debug info speeds up builds a bunch,
+# # and we don't rely on it for debugging that much.
+# debug = 0
 
-[profile.release]
-panic = "abort"
-opt-level = "z"
-lto = true
+# [profile.release]
+# panic = "abort"
+# opt-level = "z"
+# lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ once_cell = "1.15.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_yaml = "0.9.13"
 serde_json = "1.0.85"
-sodiumoxide = "0.2.7"
-sealed-box = { path = "../sealed_box/" }
 crypto_box = { git = "https://github.com/RustCrypto/nacl-compat.git", rev = "0a0c83f99f37340aeab1a3ce083e9e22080cf6ff", features = ["seal"]}
 hex = "0.4.3"
+sha2 = "0.10.6"
+base64 = "0.13.1"
 
 [build-dependencies]
 anyhow = "1.0.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ vergen = { version = "7.4.2", default-features = false, features = ["git"] }
 assert_cmd = "2.0.4"
 tempfile = "3.3.0"
 
-# [profile.dev]
-# # Disabling debug info speeds up builds a bunch,
-# # and we don't rely on it for debugging that much.
-# debug = 0
+[profile.dev]
+# Disabling debug info speeds up builds a bunch,
+# and we don't rely on it for debugging that much.
+debug = 0
 
-# [profile.release]
-# panic = "abort"
-# opt-level = "z"
-# lto = true
+[profile.release]
+panic = "abort"
+opt-level = "z"
+lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.15.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_yaml = "0.9.13"
 serde_json = "1.0.85"
-crypto_box = { git = "https://github.com/RustCrypto/nacl-compat.git", rev = "0a0c83f99f37340aeab1a3ce083e9e22080cf6ff", features = ["seal"]}
+crypto_box = { version = "0.8.2", features = ["seal"]}
 hex = "0.4.3"
 sha2 = "0.10.6"
 base64 = "0.13.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,11 +206,9 @@ impl Config {
         &'a self,
         secret_key: &'a SecretKey,
     ) -> impl Iterator<Item = Result<(&'a String, String)>> {
-        self.secrets.iter().map(move |(key, secret)| {
-            secret
-                .decrypt(secret_key, key)
-                .map(|plain| (key, plain))
-        })
+        self.secrets
+            .iter()
+            .map(move |(key, secret)| secret.decrypt(secret_key, key).map(|plain| (key, plain)))
     }
 
     /// Look up a specific secret value

--- a/src/config.rs
+++ b/src/config.rs
@@ -231,7 +231,6 @@ impl Secret {
             raw.name,
             Secret {
                 sha256: digest,
-                // sha256: hasher.finalize_reset().into(),
                 cipher: hex::decode(&raw.cipher)
                     .ok()
                     .context("Non-hex ciphertext")?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,7 +181,7 @@ impl Config {
     pub fn load_secret_key(&self) -> Result<SecretKey> {
         (|| {
             let hex = std::env::var(SECRET_KEY_ENV)?;
-            let bs: [u8; 32] = hex::decode(&hex)
+            let bs: [u8; 32] = hex::decode(hex)
                 .ok()
                 .context("Invalid hex encoding")?
                 .try_into()

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod mask;
 use std::{io::Read, path::Path};
 
 use anyhow::*;
-use base64::{encode, encode_config};
+use base64::encode_config;
 use crypto_box::{SecretKey, rand_core::OsRng};
 use exec::CommandExecExt;
 use serde::Serialize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod mask;
 use std::{io::Read, path::Path};
 
 use anyhow::*;
+use base64::{encode, encode_config};
+use crypto_box::{SecretKey, rand_core::OsRng};
 use exec::CommandExecExt;
 use serde::Serialize;
 
@@ -100,8 +102,8 @@ fn encrypt(mut opt: cli::Opt, key: String, value: Option<String>) -> Result<()> 
 }
 
 fn generate(opt: cli::Opt, key: String) -> Result<()> {
-    let value = sodiumoxide::randombytes::randombytes(16);
-    let value = sodiumoxide::base64::encode(value, sodiumoxide::base64::Variant::UrlSafe);
+    let value = SecretKey::generate(&mut OsRng);
+    let value = encode_config(&value.as_bytes(), base64::URL_SAFE);
     let msg = format!("Your new secret value is {}: {}", key, value);
     encrypt(opt, key, Some(value))?;
     println!("{}", &msg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn encrypt(mut opt: cli::Opt, key: String, value: Option<String>) -> Result<()> 
 
 fn generate(opt: cli::Opt, key: String) -> Result<()> {
     let value = SecretKey::generate(&mut OsRng);
-    let value = encode_config(&value.as_bytes(), base64::URL_SAFE);
+    let value = encode_config(value.as_bytes(), base64::URL_SAFE);
     let msg = format!("Your new secret value is {}: {}", key, value);
     encrypt(opt, key, Some(value))?;
     println!("{}", &msg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
 
 fn init(mut opt: cli::Opt, only_secret_key: bool) -> Result<()> {
     let (secret_key, config) = config::Config::new();
-    let secret_key = sodiumoxide::hex::encode(secret_key);
+    let secret_key = hex::encode(secret_key.as_bytes());
 
     config.save(opt.find_amber_yaml_or_default())?;
 
@@ -95,7 +95,7 @@ fn encrypt(mut opt: cli::Opt, key: String, value: Option<String>) -> Result<()> 
         },
         Ok,
     )?;
-    config.encrypt(key, &value);
+    config.encrypt(key, &value)?;
     config.save(amber_yaml)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{io::Read, path::Path};
 
 use anyhow::*;
 use base64::encode_config;
-use crypto_box::{SecretKey, rand_core::OsRng};
+use crypto_box::{rand_core::OsRng, SecretKey};
 use exec::CommandExecExt;
 use serde::Serialize;
 


### PR DESCRIPTION
From last year, sodiumoxide has been unmaintained and there is a RUSTSEC advisory filed that has deprecated it's usage: https://rustsec.org/advisories/RUSTSEC-2021-0137.html

Also the original author of the crate has archived the repository.

This PR switches to use the crate crypto_box which is a pure Rust compatibility layer for Nacl libraries. I also had to use some other crates for computing SHA, hex decoding etc.